### PR TITLE
Add user following

### DIFF
--- a/src/main/java/org/ppke/itk/listen/controller/UserController.java
+++ b/src/main/java/org/ppke/itk/listen/controller/UserController.java
@@ -37,4 +37,24 @@ public class UserController {
         return userRepository.findById(id)
                 .orElseThrow(() -> new NoSuchElementException("Could not find " + User.class.getSimpleName() + " with the id: " + id));
     }
+
+    @GetMapping(value ="/{id}/followers", produces = "application/json")
+    public List<User> getUserFollowers(@PathVariable("id") Long id) {
+        log.info("Calling GET /users/{id}/followers endpoint.");
+
+        User foundUser = userRepository.findById(id)
+                .orElseThrow(() -> new NoSuchElementException("Could not find " + User.class.getSimpleName() + " with the id: " + id));
+
+        return foundUser.getFollowerUsers();
+    }
+
+    @GetMapping(value ="/{id}/following", produces = "application/json")
+    public List<User> getUserFollowing(@PathVariable("id") Long id) {
+        log.info("Calling GET /users/{id}/following endpoint.");
+
+        User foundUser = userRepository.findById(id)
+                .orElseThrow(() -> new NoSuchElementException("Could not find " + User.class.getSimpleName() + " with the id: " + id));
+
+        return foundUser.getFollowedUsers();
+    }
 }

--- a/src/main/java/org/ppke/itk/listen/domain/user/data/User.java
+++ b/src/main/java/org/ppke/itk/listen/domain/user/data/User.java
@@ -7,6 +7,11 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import javax.persistence.*;
 
 @Getter
@@ -32,8 +37,18 @@ public class User extends BaseEntity {
 
     //Favorited UserTracks
 
-    //Followed Users
+    @ManyToMany
+    @JoinTable(
+        name = "user_followings", 
+        joinColumns = @JoinColumn(name = "follower_user_id"), 
+        inverseJoinColumns = @JoinColumn(name = "followed_user_id"))
+    @Builder.Default
+    @JsonIgnore
+    private List<User> followedUsers = new ArrayList<>();
 
-    //Followers
+    @ManyToMany(mappedBy = "followedUsers")
+    @Builder.Default
+    @JsonIgnore
+    private List<User> followerUsers = new ArrayList<>();
 }
 

--- a/src/main/resources/db/migration/V1__add_user.sql
+++ b/src/main/resources/db/migration/V1__add_user.sql
@@ -9,7 +9,7 @@ created_on DATE,
 last_modified_on DATE
 );
 
-insert into users(name, description, avatar_url) values ('Wolfgand Amadeus Mozard', ' Prolific and influential composer of the Classical period', 'https://ui-avatars.com/api/?name=Mozart');
+insert into users(name, description, avatar_url) values ('Wolfgang Amadeus Mozard', ' Prolific and influential composer of the Classical period', 'https://ui-avatars.com/api/?name=Mozart');
 insert into users(name, description, avatar_url) values ('Kanye West', 'ye', 'https://ui-avatars.com/api/?name=Kanye');
 insert into users(name, description, avatar_url) values ('Klangkarussell', '', 'https://ui-avatars.com/api/?name=Klangkarussell');
 insert into users(name, description, avatar_url) values ('Joe_11', 'I just listen to music', 'https://ui-avatars.com/api/?name=Joe_11');

--- a/src/main/resources/db/migration/V2__add_user_following.sql
+++ b/src/main/resources/db/migration/V2__add_user_following.sql
@@ -1,0 +1,21 @@
+CREATE TABLE "user_followings" (
+follower_user_id BIGINT REFERENCES users (id) ON UPDATE CASCADE ON DELETE CASCADE,
+followed_user_id BIGINT REFERENCES users (id) ON UPDATE CASCADE ON DELETE CASCADE,
+CONSTRAINT user_following_pkey PRIMARY KEY (follower_user_id, followed_user_id)
+);
+
+insert into user_followings(follower_user_id, followed_user_id) 
+    select * from (select id as follower_user_id from users where name = 'Daniel88') t1 
+    cross join (select id as followed_user_id from users where name = 'Wolfgang Amadeus Mozard') t2;
+insert into user_followings(follower_user_id, followed_user_id) 
+    select * from (select id as follower_user_id from users where name = 'Kanye West') t1
+    cross join (select id as followed_user_id from users where name = 'Wolfgang Amadeus Mozard') t2;
+insert into user_followings(follower_user_id, followed_user_id) 
+    select * from (select id as follower_user_id from users where name = 'Klangkarussell') t1
+    cross join (select id as followed_user_id from users where name = 'Wolfgang Amadeus Mozard') t2;
+insert into user_followings(follower_user_id, followed_user_id) 
+    select * from (select id as follower_user_id from users where name = 'Daniel88') t1
+    cross join (select id as followed_user_id from users where name = 'Klangkarussell') t2;
+insert into user_followings(follower_user_id, followed_user_id) 
+    select * from (select id as follower_user_id from users where name = 'Joe_11') t1
+    cross join (select id as followed_user_id from users where name = 'Kanye West') t2;


### PR DESCRIPTION
Extends the User model to be able to handle following logic between users:

- Added `followerUsers` and `followedUsers` User-lists to User Entity
- API endpoints created to query these fields
  - Added `users/{id}/following` endpoint to query who a user follow
  - Added `users/{id}/followers` endpoint to query the followers of a user