### PR TITLE
Add user-tracks

### DIFF
--- a/src/main/java/org/ppke/itk/listen/controller/UserController.java
+++ b/src/main/java/org/ppke/itk/listen/controller/UserController.java
@@ -2,7 +2,6 @@ package org.ppke.itk.listen.controller;
 
 import org.ppke.itk.listen.domain.user.data.User;
 import org.ppke.itk.listen.domain.user.repository.UserRepository;
-import org.springframework.util.StopWatch;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;

--- a/src/main/java/org/ppke/itk/listen/controller/UserTrackController.java
+++ b/src/main/java/org/ppke/itk/listen/controller/UserTrackController.java
@@ -4,8 +4,12 @@ import java.util.NoSuchElementException;
 
 import org.ppke.itk.listen.domain.usertrack.data.UserTrack;
 import org.ppke.itk.listen.domain.usertrack.repository.UserTrackRepository;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,9 +26,39 @@ public class UserTrackController {
 
     @GetMapping(value ="/{id}", produces = "application/json")
     public UserTrack getTeamById(@PathVariable("id") Long id) {
-        log.info("Calling GET /users/{id} endpoint.");
+        log.info("Calling GET /user-tracks/{id} endpoint.");
 
         return userTrackRepository.findById(id)
                 .orElseThrow(() -> new NoSuchElementException("Could not find " + UserTrack.class.getSimpleName() + " with the id: " + id));
+    }
+
+    @PostMapping
+    public UserTrack saveNewTrack(@RequestBody UserTrack userTrack) {
+        UserTrack track = userTrackRepository.save(userTrack);
+        return track;
+
+        // TODO: Don't allow update (Solution: Dto)
+    }
+
+    @PutMapping(value ="/{id}")
+    public UserTrack updateUserTrack(@RequestBody UserTrack userTrack, @PathVariable("id") Long id) {
+        UserTrack trackToUpdate = userTrackRepository.findById(id)
+                .orElseThrow(() -> new NoSuchElementException("Could not find " + UserTrack.class.getSimpleName() + " with the id: " + id));
+
+        trackToUpdate.setName(userTrack.getName());
+        trackToUpdate.setAudioUrl(userTrack.getAudioUrl());
+        trackToUpdate.setPictureUrl(userTrack.getPictureUrl());
+
+        return userTrackRepository.save(userTrack);
+
+        // TODO: Fails if input userTrack has an invalid userId inside ownerUser
+        // TODO: Weird things when path ID and userTrack.id doesn't match
+    }
+
+    @DeleteMapping(value ="/{id}")
+    public void deleteTrack(@PathVariable("id") Long id) {
+        userTrackRepository.deleteById(id);
+
+        // TODO: Handle not found (It's 500 now)
     }
 }

--- a/src/main/java/org/ppke/itk/listen/controller/UserTrackController.java
+++ b/src/main/java/org/ppke/itk/listen/controller/UserTrackController.java
@@ -69,9 +69,11 @@ public class UserTrackController {
 
     @DeleteMapping(value ="/{id}")
     public void deleteTrack(@PathVariable("id") Long id) {
-        userTrackRepository.deleteById(id);
+        UserTrack trackToDelete = userTrackRepository.findById(id)
+                .orElseThrow(() -> new NoSuchElementException("Could not find " + UserTrack.class.getSimpleName() + " with the id: " + id));
 
-        // TODO: Handle not found (It's 500 now)
+        userTrackRepository.delete(trackToDelete);
+        
         // TODO: Only allow track delete for authenticated user for their ids
     }
 }

--- a/src/main/java/org/ppke/itk/listen/controller/UserTrackController.java
+++ b/src/main/java/org/ppke/itk/listen/controller/UserTrackController.java
@@ -1,0 +1,30 @@
+package org.ppke.itk.listen.controller;
+
+import java.util.NoSuchElementException;
+
+import org.ppke.itk.listen.domain.usertrack.data.UserTrack;
+import org.ppke.itk.listen.domain.usertrack.repository.UserTrackRepository;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/user-tracks")
+public class UserTrackController {
+
+    private final UserTrackRepository userTrackRepository;
+
+    @GetMapping(value ="/{id}", produces = "application/json")
+    public UserTrack getTeamById(@PathVariable("id") Long id) {
+        log.info("Calling GET /users/{id} endpoint.");
+
+        return userTrackRepository.findById(id)
+                .orElseThrow(() -> new NoSuchElementException("Could not find " + UserTrack.class.getSimpleName() + " with the id: " + id));
+    }
+}

--- a/src/main/java/org/ppke/itk/listen/domain/BaseEntity.java
+++ b/src/main/java/org/ppke/itk/listen/domain/BaseEntity.java
@@ -11,11 +11,9 @@ import java.util.Date;
 public class BaseEntity {
 
     @Column(name = "created_on")
-    @JsonIgnore
     private Date createdOn;
 
     @Column(name = "last_modified_on")
-    @JsonIgnore
     private Date modifiedOn;
 
     @PrePersist

--- a/src/main/java/org/ppke/itk/listen/domain/user/data/User.java
+++ b/src/main/java/org/ppke/itk/listen/domain/user/data/User.java
@@ -1,6 +1,8 @@
 package org.ppke.itk.listen.domain.user.data;
 
 import org.ppke.itk.listen.domain.BaseEntity;
+import org.ppke.itk.listen.domain.usertrack.data.UserTrack;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -33,11 +35,12 @@ public class User extends BaseEntity {
     @Column(name = "avatar_url")
     private String avatarUrl;
 
-    //Owned UserTraccks
+    @OneToMany(fetch = FetchType.LAZY, mappedBy ="ownerUser")
+    private List<UserTrack> userTracks;
 
     //Favorited UserTracks
 
-    @ManyToMany
+    @ManyToMany(fetch = FetchType.LAZY)
     @JoinTable(
         name = "user_followings", 
         joinColumns = @JoinColumn(name = "follower_user_id"), 
@@ -46,7 +49,7 @@ public class User extends BaseEntity {
     @JsonIgnore
     private List<User> followedUsers = new ArrayList<>();
 
-    @ManyToMany(mappedBy = "followedUsers")
+    @ManyToMany(mappedBy = "followedUsers", fetch = FetchType.LAZY)
     @Builder.Default
     @JsonIgnore
     private List<User> followerUsers = new ArrayList<>();

--- a/src/main/java/org/ppke/itk/listen/domain/user/data/User.java
+++ b/src/main/java/org/ppke/itk/listen/domain/user/data/User.java
@@ -35,7 +35,8 @@ public class User extends BaseEntity {
     @Column(name = "avatar_url")
     private String avatarUrl;
 
-    @OneToMany(fetch = FetchType.LAZY, mappedBy ="ownerUser")
+    @OneToMany(fetch = FetchType.LAZY, mappedBy ="ownerUser", cascade = CascadeType.ALL)
+    @JsonIgnore
     private List<UserTrack> userTracks;
 
     //Favorited UserTracks

--- a/src/main/java/org/ppke/itk/listen/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/ppke/itk/listen/domain/user/repository/UserRepository.java
@@ -12,13 +12,4 @@ public interface UserRepository extends JpaRepository<User, Long> {
     List<User> findAll();
 
     Optional<User> findById(Long id);
-
-    /* 
-    public List<User> getTeams() {
-        return List.of(
-            new User(0, "Marco Polo", "One of the greatest adventurer of our world", "https://www.worldometers.info/img/flags/br-flag.gif"),
-            new User(1, "Colombus Christoph", "India is so nice", "https://www.worldometers.info/img/flags/br-flag.gif")
-        );
-    }
-    */
 }

--- a/src/main/java/org/ppke/itk/listen/domain/usertrack/data/UserTrack.java
+++ b/src/main/java/org/ppke/itk/listen/domain/usertrack/data/UserTrack.java
@@ -1,20 +1,35 @@
 package org.ppke.itk.listen.domain.usertrack.data;
 
 import org.ppke.itk.listen.domain.BaseEntity;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-// import lombok.EqualsAndHashCode;
+import org.ppke.itk.listen.domain.user.data.User;
 
-@Data
-// @EqualsAndHashCode(callSuper=false)
+import javax.persistence.*;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
 @AllArgsConstructor
+@NoArgsConstructor
+@Entity
+@Table(name ="user_tracks")
 public class UserTrack extends BaseEntity {
-    private Integer id;
+
+    @Id
+    @GeneratedValue(strategy=GenerationType.IDENTITY)
+    private Long id;
+
     private String name;
+
+    @Column(name = "picture_url")
     private String pictureUrl;
+
+    @Column(name = "audio_url")
     private String audioUrl;
 
-    //owner userId
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name ="owner_user_id")
+    private User ownerUser;
 
     //Favorites 
 }

--- a/src/main/java/org/ppke/itk/listen/domain/usertrack/repository/UserTrackRepository.java
+++ b/src/main/java/org/ppke/itk/listen/domain/usertrack/repository/UserTrackRepository.java
@@ -1,6 +1,5 @@
 package org.ppke.itk.listen.domain.usertrack.repository;
 
-import java.util.List;
 import java.util.Optional;
 
 import org.ppke.itk.listen.domain.usertrack.data.UserTrack;
@@ -9,7 +8,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserTrackRepository extends JpaRepository<UserTrack, Long> {
-    List<UserTrack> findAll();
-
     Optional<UserTrack> findById(Long id);
 }

--- a/src/main/java/org/ppke/itk/listen/domain/usertrack/repository/UserTrackRepository.java
+++ b/src/main/java/org/ppke/itk/listen/domain/usertrack/repository/UserTrackRepository.java
@@ -1,0 +1,15 @@
+package org.ppke.itk.listen.domain.usertrack.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.ppke.itk.listen.domain.usertrack.data.UserTrack;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserTrackRepository extends JpaRepository<UserTrack, Long> {
+    List<UserTrack> findAll();
+
+    Optional<UserTrack> findById(Long id);
+}

--- a/src/main/java/org/ppke/itk/listen/model/NewUserTrack.java
+++ b/src/main/java/org/ppke/itk/listen/model/NewUserTrack.java
@@ -1,0 +1,12 @@
+package org.ppke.itk.listen.model;
+
+import lombok.Data;
+
+@Data
+public class NewUserTrack {
+
+    private String name;
+    private String pictureUrl;
+    private String audioUrl;
+    private Long ownerUserId;
+}

--- a/src/main/resources/db/migration/V2__add_user_following.sql
+++ b/src/main/resources/db/migration/V2__add_user_following.sql
@@ -1,3 +1,5 @@
+DROP TABLE IF EXISTS "user_followings";
+
 CREATE TABLE "user_followings" (
 follower_user_id BIGINT REFERENCES users (id) ON UPDATE CASCADE ON DELETE CASCADE,
 followed_user_id BIGINT REFERENCES users (id) ON UPDATE CASCADE ON DELETE CASCADE,

--- a/src/main/resources/db/migration/V3__add_user_tracks.sql
+++ b/src/main/resources/db/migration/V3__add_user_tracks.sql
@@ -1,0 +1,18 @@
+DROP TABLE IF EXISTS "user_tracks";
+
+CREATE TABLE "user_tracks" (
+id BIGINT NOT NULL PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+owner_user_id BIGINT REFERENCES users (id) ON UPDATE CASCADE ON DELETE CASCADE,
+name VARCHAR(255) NOT NULL,
+picture_url VARCHAR(255),
+audio_url VARCHAR(255),
+created_on DATE,
+last_modified_on DATE
+);
+
+insert into user_tracks(owner_user_id, name, picture_url, audio_url) select id, 'Requiem, K. 626: Lacrimosa', 'https://picsum.photos/200', 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp' from users where name = 'Wolfgang Amadeus Mozard';
+insert into user_tracks(owner_user_id, name, picture_url, audio_url) select id, 'Die Hochzeit des Figaro', 'https://picsum.photos/200', 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp' from users where name = 'Wolfgang Amadeus Mozard';
+insert into user_tracks(owner_user_id, name, picture_url, audio_url) select id, 'POWER', 'https://picsum.photos/200', 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp' from users where name = 'Kanye West';
+insert into user_tracks(owner_user_id, name, picture_url, audio_url) select id, 'Flashing Lights', 'https://picsum.photos/200', 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp' from users where name = 'Kanye West';
+insert into user_tracks(owner_user_id, name, picture_url, audio_url) select id, 'Sonnentanz - Sun Don''t Shine', 'https://picsum.photos/200', 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp' from users where name = 'Klangkarussell';
+insert into user_tracks(owner_user_id, name, picture_url, audio_url) select id, 'Plastic', 'https://picsum.photos/200', 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp' from users where name = 'Klangkarussell';


### PR DESCRIPTION
Add UserTrack Entity with CRUD functions. The following endpoints have been added:

- GET `/user-tracks/{id}` returns the user-track with the given ID
- POST `user-tracks` adds a new user-track to the DB 
  - Requires a NewUserTrack object in the body
- PUT `/user-tracks/{id}` updates a user-track on the given ID 
  - Requires a NewUserTrack object in the body
- DELETE `/user-tracks/{id}` removes the user-track on the given ID